### PR TITLE
Fix Typo in CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           name: Setup Org
           command: |
             echo 'Running tests'
-            sfdx force:auth:jwt:grant --clientid $HUB_CONSUMER_KEY --jwtkeyfile assets/server.key --username $HUB_SFDC_USER --setdefaultdevhubusername -a hub
+            sfdx force:auth:jwt:grant --clientid $HUB_CONSUMER_KEY --jwtkeyfile assets/server.key --username $HUB_SFDX_USER --setdefaultdevhubusername -a hub
             sfdx force --help
             sfdx force:org:create -s -f ~/ci_app/config/project-scratch-def.json -a circle_build_$CIRCLE_BUILD_NUM --wait 2
             sfdx force:source:push -u circle_build_$CIRCLE_BUILD_NUM


### PR DESCRIPTION
According to to the Readme.MD file, the SFDX user should be stored in $HUB_SFDX_USER, but the config.yaml file is checking the $HUB_SFDC_USER  (SFDC instead of SFDX).

This is to update the username argument used in the circleci config.yml file to check the parameter defined in the Readme.MD / CircleCI environment variable.