### PR TITLE
Fix deprecated OrgPreferences

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,7 +1,9 @@
 {
     "orgName": "wade.wegner Example",
     "edition": "Developer",
-    "orgPreferences" : {
-        "enabled": ["S1DesktopEnabled"]
+    "settings": {
+        "lightningExperienceSettings": {
+           "enableS1DesktopEnabled": true
+        }
     }
 }


### PR DESCRIPTION
Fix definition file to create scrach org.
As I fixed deprecated OrgPreferences , I got the following message.

> We've deprecated OrgPreferences. Update the scratch org definition file to replace OrgPreferences with their corresponding settings.
> 
> Replace the orgPreferences section:
> {
>     "orgPreferences": {
>         "enabled": [
>             "S1DesktopEnabled"
>         ]
>     }
> }
> With their updated settings:
> {
>     "settings": {
>         "lightningExperienceSettings": {
>             "enableS1DesktopEnabled": true
>         }
>     }
> }



